### PR TITLE
Add fall damage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainboom"
-description = "A 3D reference project and tech demo for the Bevy Engine."
+description = "A first-person shooter with explosive zombies. A submission for Bevy Jam 6."
 license = "MIT OR Apache-2.0 OR CC0-1.0"
 authors = ["Jan Hohenheim <jan@hohenheim.ch>"]
 version = "0.1.0"

--- a/src/gameplay/npc/despawn_hacks.rs
+++ b/src/gameplay/npc/despawn_hacks.rs
@@ -6,12 +6,15 @@ use crate::{
         health::OnDamage,
         npc::{Npc, ai_state::AiState},
     },
+    menus::game_over::GameOverMenu,
 };
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(
         Update,
-        (despawn_lazy, despawn_lonely).in_set(PostPhysicsAppSystems::TickTimers),
+        (despawn_lazy, despawn_lonely)
+            .in_set(PostPhysicsAppSystems::TickTimers)
+            .run_if(|query: Query<&GameOverMenu>| query.is_empty()),
     );
     app.add_observer(init_last_translation);
 }

--- a/src/gameplay/player/fall_damage.rs
+++ b/src/gameplay/player/fall_damage.rs
@@ -1,0 +1,51 @@
+use avian3d::prelude::LinearVelocity;
+use bevy::prelude::*;
+
+use crate::{
+    gameplay::{
+        health::{Health, OnDamage},
+        player::{GroundCast, Player},
+    },
+    screens::Screen,
+};
+
+pub(super) fn plugin(app: &mut App) {
+    app.add_systems(
+        FixedUpdate,
+        apply_fall_damage.run_if(in_state(Screen::Gameplay)),
+    );
+}
+
+const FALL_DAMAGE_THRESHOLD: f32 = 35.0;
+
+fn apply_fall_damage(
+    mut commands: Commands,
+    player: Single<(Entity, &Health, &GroundCast, &LinearVelocity), With<Player>>,
+    mut local: Local<(bool, f32)>,
+) {
+    let (was_airborne, last_y_speed) = &mut *local;
+    let (entity, health, ground_cast, velocity) = *player;
+    let is_airborne = ground_cast.is_none();
+    if is_airborne {
+        *was_airborne = true;
+        *last_y_speed = velocity.y.abs();
+        return;
+    }
+    if !*was_airborne {
+        *last_y_speed = velocity.y.abs();
+        return;
+    }
+    *was_airborne = false;
+
+    if *last_y_speed < FALL_DAMAGE_THRESHOLD {
+        *last_y_speed = velocity.y.abs();
+        return;
+    }
+
+    let max_damage = health.max / 4.0;
+    let damage = (1.5 * (*last_y_speed - FALL_DAMAGE_THRESHOLD)).min(max_damage);
+
+    commands.trigger_targets(OnDamage(damage), entity);
+
+    *last_y_speed = velocity.y.abs();
+}


### PR DESCRIPTION
- Add fall damage, only applying it if you hit the ground hard enough, clamping damage to below 25% of total health
- Currently it's weird because you fall slower if you jump first rather than just running off of an edge
- Also fixed a bug with enemies getting auto-killed even when the game has ended
- Update description in Cargo.toml